### PR TITLE
Add support for site autoloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The `autoload.php` file should contain rules for the package. For example:
 
 use Silverorange\Autoloader;
 
-$package = new Package('silverorange/site');
+$package = new Package(__DIR__);
 
 $package->addRule(
   new Rule(

--- a/lib/Autoloader.php
+++ b/lib/Autoloader.php
@@ -23,9 +23,14 @@ class Autoloader
 	// {{{ private properties
 
 	/**
-	 * @var arary
+	 * @var array
 	 */
 	private static $packages = array();
+
+	/**
+	 * @var Package
+	 */
+	private static $final_package;
 
 	// }}}
 	// {{{ public static function addPackage()
@@ -58,6 +63,51 @@ class Autoloader
 	}
 
 	// }}}
+	// {{{ public static function addFinalPackage()
+
+	/**
+	 * Sets an autoloader package as the last package to check against
+	 *
+	 * @param Package $package the autoloader package to add.
+	 *
+	 * @return void
+	 */
+	public static function setFinalPackage(Package $package)
+	{
+		self::$final_package = $package;
+	}
+
+	// }}}
+	// {{{ public static function removeFinalPackage()
+
+	/**
+	 * Removes the final autoloader package from the autoloader
+	 *
+	 * @return void
+	 */
+	public static function removeFinalPackage()
+	{
+		self::$final_package = null;
+	}
+
+	// }}}
+	// {{{ public static function getPackages()
+
+	/**
+	 * @return array
+	 */
+	public static function getPackages()
+	{
+		$packages = self::$packages;
+
+		if (self::$final_package instanceof Package) {
+			$packages[] = self::$final_package;
+		}
+
+		return $packages;
+	}
+
+	// }}}
 	// {{{ public static function getFileFromClass()
 
 	/**
@@ -77,11 +127,11 @@ class Autoloader
 	{
 		$filename = null;
 
-		foreach (self::$packages as $package) {
+		foreach (self::getPackages() as $package) {
 			foreach ($package->getRules() as $rule) {
 				$result = $rule->apply($className);
 				if ($result !== null) {
-					$filename = $package->getName() .
+					$filename = $package->getDirectory() .
 						DIRECTORY_SEPARATOR . $result;
 
 					break 2;
@@ -107,18 +157,12 @@ class Autoloader
 	 */
 	public static function autoload($className)
 	{
-		static $vendorDir = null;
-
-		if ($vendorDir === null) {
-			$vendorDir = dirname(dirname(dirname(__DIR__)));
-		}
-
 		$filename = self::getFileFromClass($className);
 
 		// We do not throw an exception here because is_callable() will break.
 
 		if ($filename !== null) {
-			require $vendorDir . DIRECTORY_SEPARATOR . $filename;
+			require $filename;
 		}
 	}
 

--- a/lib/Package.php
+++ b/lib/Package.php
@@ -33,37 +33,36 @@ class Package
 	/**
 	 * Creates a new autoloader package
 	 *
-	 * @param string $name the name of the package. Use the composer package
-	 *                     name.
+	 * @param string $directory the root directory of the package.
 	 */
-	public function __construct($name)
+	public function __construct($directory)
 	{
-		$this->setName($name);
+		$this->setDirectory($directory);
 	}
 
 	// }}}
-	// {{{ public function setName()
+	// {{{ public function setDirectory()
 
 	/**
-	 * @param string $name
+	 * @param string $directory
 	 *
 	 * @return Package
 	 */
-	public function setName($name)
+	public function setDirectory($directory)
 	{
-		$this->name = (string)$name;
+		$this->directory = (string)$directory;
 		return $this;
 	}
 
 	// }}}
-	// {{{ public function getName()
+	// {{{ public function getDirectory()
 
 	/**
 	 * @return string
 	 */
-	public function getName()
+	public function getDirectory()
 	{
-		return $this->name;
+		return $this->directory;
 	}
 
 	// }}}

--- a/lib/Rule.php
+++ b/lib/Rule.php
@@ -13,7 +13,7 @@ namespace Silverorange\Autoloader;
  *
  * If a class name matches a rule, the filename is built as:
  *
- *  <start-prefix>/<directory>/<class-name>.php
+ *  [<start-prefix>/]<directory>/<class-name>.php
  *
  * @package   Silverorange_Autoloader
  * @copyright 2006-2016 silverorange
@@ -176,7 +176,9 @@ class Rule
 		$filename = null;
 
 		if ($this->matches($className)) {
-			$filename = $this->startsWith . DIRECTORY_SEPARATOR;
+			if ($this->startsWith != '') {
+				$filename .= $this->startsWith . DIRECTORY_SEPARATOR;
+			}
 
 			if ($this->directory != '') {
 				$filename .= $this->directory . DIRECTORY_SEPARATOR;


### PR DESCRIPTION
These changes allow us to autoload classes defined in site directories.

The autoload rules for a site are defined in the same way that package autoload rules are defined. These site specific rules have no `startsWith` prefix defined. Since there is no `startPrefix` and the final rule will have no `endsWith` argument the package must be added the final rule to be checked (with the `Autoloader::addFinalPackage()` method). The package needs to be the final package checked since the final rule will match every class name.

 These changes also remove a limitation that prevented us from autoloading packages that were symbolically linked (like we do with out development packages). The constructor of the package has changed to now accept the directory containing the package (Use the magic `__DIR__` constant) instead of the package name.
